### PR TITLE
upgrade to latest expo-crypt to support expo sdk50 builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@criipto/oidc": "1.3.2",
     "base-64": "^1.0.0",
-    "expo-crypto": "~12.4.1",
+    "expo-crypto": "~12.8.1",
     "expo-web-browser": "^12.3.2",
     "js-tokens": "^4.0.0",
     "jwt-decode": "^3.1.2",


### PR DESCRIPTION
java17 vs. java11