### PR TITLE
Explicit expo-linking peerDependency version number to fix expo sdk51 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "text-encoding": "^0.7.0"
   },
   "peerDependencies": {
-    "expo-linking": "*",
+    "expo-linking": "^6.3.1",
     "react": "^18.0.0",
     "react-native": "*"
   },


### PR DESCRIPTION
got a version err when running npx expo-doctor@latest, as older version of expo-linking was installed.