### PR TITLE
add(login): expose preferEphemeralSession from expo-web-browser.

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -41,7 +41,7 @@ export interface CriiptoVerifyContextInterface {
   login: (
     acrValues: AcrValues,
     redirectUri: string,
-    params?: {scope: string, login_hint: string}
+    params?: {scope: string, login_hint: string, preferEphemeralSession?: boolean}
   ) => Promise<{id_token: string, claims: Claims} | OAuth2Error | Error>,
 
   logout: () => Promise<void>,

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -148,7 +148,8 @@ const CriiptoVerifyProvider = (props: CriiptoVerifyProviderOptions) : JSX.Elemen
         setTransaction(transaction);
       });
       const browserResult = WebBrowser.openAuthSessionAsync(authorizeUrl.href, redirectUri, {
-        createTask: Platform.OS === 'android' ? false : undefined
+        createTask: Platform.OS === 'android' ? false : undefined,
+        preferEphemeralSession: params?.preferEphemeralSession ?? false
       });
 
       const url = await Promise.race([
@@ -162,7 +163,9 @@ const CriiptoVerifyProvider = (props: CriiptoVerifyProviderOptions) : JSX.Elemen
       return await handleURL(discovery, pkce, redirectUri, new URL(url));
     }
 
-    const result = await WebBrowser.openAuthSessionAsync(authorizeUrl.href, redirectUri);
+    const result = await WebBrowser.openAuthSessionAsync(authorizeUrl.href, redirectUri, {
+      preferEphemeralSession: params?.preferEphemeralSession ?? false
+    });
     
     if (result.type === 'success') {
       const url = new URL(result.url);


### PR DESCRIPTION
On iOS, this option controls whether the authentication view shares cookies with the main browser, and whether the user is prompted whether they want to 'log in with criipto.id'

Got a question about this on hubspot, and it's super straight-forward to expose the option.

If you prefer, I can also add an options object instead :)

