### PR TITLE
fix: include android folder when publishing package

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,12 @@
     "mitid",
     "bankid"
   ],
+  "files": [
+    "dist",
+    "android",
+    "expo-module.config.json",
+    "app.plugin.js"
+  ],
   "author": "",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Maybe it's no longer included, after we upgraded npm? 

Tested with `npm pack`, and with this change, the files are included.