### PR TITLE
fix(firefox): Handle redirect URI correctly.

### DIFF
--- a/android/src/main/java/expo/modules/criiptoverify/CriiptoVerifyActivity.kt
+++ b/android/src/main/java/expo/modules/criiptoverify/CriiptoVerifyActivity.kt
@@ -129,5 +129,13 @@ class CriiptoVerifyActivity : AppCompatActivity() {
         addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
       }
+
+    public fun createResponseHandlingIntent(
+      context: Context,
+      responseUri: Uri,
+    ): Intent =
+      createBaseIntent(context).apply {
+        setData(responseUri)
+      }
   }
 }

--- a/android/src/main/java/expo/modules/criiptoverify/RedirectUriReceiverActivity.kt
+++ b/android/src/main/java/expo/modules/criiptoverify/RedirectUriReceiverActivity.kt
@@ -1,0 +1,32 @@
+package expo.modules.criiptoverify
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+/**
+ * This is very heavily inspired by
+ * https://github.com/openid/AppAuth-Android/blob/4df1ebac07436d7e8d68cbb98207cc40fe55a39d/library/java/net/openid/appauth/RedirectUriReceiverActivity.java
+ *
+ * The activity which holds the custom tab (`CriiptoVerifyActivity`) expects to be called with
+ * `FLAG_ACTIVITY_CLEAR_TOP`, when receiving a redirect URL. This is in order to remove the custom
+ * tab from the stack.
+ *
+ * This works in chrome, but not in firefox. Therefore, we capture the intent here, and create a new
+ * intent, which starts `CriiptoVerifyActivity` with `FLAG_ACTIVITY_CLEAR_TOP` set.
+ */
+public class RedirectUriReceiverActivity : AppCompatActivity() {
+  @Override
+  override fun onCreate(savedInstanceBundle: Bundle?) {
+    super.onCreate(savedInstanceBundle)
+
+    val data = intent!!.getData()!!
+    if (data.getQueryParameter("error") != null || data.getQueryParameter("code") != null) {
+      // If either code or error is set, this is a regular redirect
+      startActivity(CriiptoVerifyActivity.createResponseHandlingIntent(this, data))
+    }
+    // Otherwise, it is a MitID app switch, and we should just switch back to the app, without
+    // starting a new activity
+
+    finish()
+  }
+}

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -24,6 +24,14 @@ const modifier = (config, options) => {
         "android:exported": "true",
         "android:launchMode": "singleTop",
       },
+    };
+
+    const redirectUriReceiverActivity = {
+      $: {
+        "android:name": "expo.modules.criiptoverify.RedirectUriReceiverActivity",
+        "android:exported": "true",
+        "android:launchMode": "singleTop",
+      },
       "intent-filter": androidAppLinks.map((href) => ({
         $: {
           "android:autoVerify": "true",
@@ -56,8 +64,12 @@ const modifier = (config, options) => {
       })),
     };
     application.activity = application.activity
-      .filter((s) => s["$"]["android:name"] !== "expo.modules.criiptoverify.CriiptoVerifyActivity")
-      .concat([criiptoVerifyActivity]);
+      .filter(
+        (s) =>
+          s["$"]["android:name"] !== criiptoVerifyActivity["$"]["android:name"] &&
+          s["$"]["android:name"] !== redirectUriReceiverActivity["$"]["android:name"],
+      )
+      .concat([criiptoVerifyActivity, redirectUriReceiverActivity]);
     return config;
   });
 };


### PR DESCRIPTION
CriiptoVerifyActivity expects to be invoked with `FLAG_ACTIVITY_CLEAR_TOP`, when receiving a redirect URL. This is in order to clear the custom tab from the stack.

However, firefox does not set this flag. So we create a proxy activity, which captures the redirect URL, and sets the flag.

## QA
Confirmed that example app works on android, in chrome and firefox. Tested both with and without app switch.