### PR TITLE
Add a mock-ACR login option to the example app

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -46,6 +46,7 @@ function LoginButton() {
         onPress={() => handlePress("urn:grn:authn:no:bankid:substantial")}
         title="Login with Norwegian BankID"
       />
+      <Button onPress={() => handlePress("urn:grn:authn:mock")} title="Login with Mock" />
 
       {error ? <Text>An error occurred: {error.toString()}</Text> : null}
 


### PR DESCRIPTION
The example previously only exposed Danish MitID, Swedish/Finnish/Norwegian BankID logins, all of which require a real identity and hands-on interaction. Add a "Login with Mock" button that drives `urn:grn:authn:mock`, which the Criipto samples tenant completes without any user input. This unblocks an upcoming smoke-test suite that exercises the end-to-end login flow on an iOS simulator / Android emulator in CI.