### PR TITLE
Scaffold Maestro smoke-test flow for the example app

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,62 @@
+# Developing
+
+How to work on `@criipto/verify-expo` and test changes in the bundled
+`example/` app.
+
+## Build commands
+
+- `npm run check` — typecheck `src/` (`tsc --noEmit`).
+- `npm run build` — emit `dist/` (the published JS + type declarations).
+- `npm run pack` — `npm run build`, then `npm pack` into a local `.tgz` tarball.
+
+## Testing changes in the example app
+
+The `example/` app depends on the **published** `@criipto/verify-expo` from npm,
+so it builds and runs on its own (a fresh clone, CI, the Maestro smoke tests).
+To test **unpublished** local changes you must install a packed tarball of the
+library into the example — not a relative path (`"file:.."`) or `npm link`.
+
+### Why a tarball, and not `file:..` / `npm link`
+
+Both `file:..` and `npm link` install the library as a **symlink to this
+repository root**. Expo's Android autolinking follows that symlink and resolves
+the library's peer dependencies — including `expo-modules-core` — from the
+**repo root's** `node_modules`.
+
+The repo root is not pinned to the example's Expo SDK. Its peer ranges
+(`expo >=54`, `expo-modules-core >=3`) resolve to the newest published Expo when
+you `npm install` here, so the root easily ends up on a newer SDK (e.g. 55/56)
+than the SDK 54 example. When that happens, the root's newer `expo-modules-core`
+is used to compile the example's SDK-54 modules, and the Android build fails with
+errors such as:
+
+```
+e: ConstantsService.kt: Class 'ConstantsService' is not abstract and does not
+   implement abstract members ...
+e: 'getConstants' overrides nothing.
+```
+
+A packed tarball sidesteps this: npm extracts it into a **real directory** under
+`example/node_modules`, with nothing pointing back to the repo root, so
+autolinking resolves `expo-modules-core` from the example's own SDK-54 install.
+
+### Workflow
+
+```sh
+# repo root — build and pack the library
+npm run pack                       # → criipto-verify-expo-<version>.tgz
+
+# example — overlay the packed build over the published dependency
+cd example
+npm ci
+npm install ../criipto-verify-expo-*.tgz --no-save
+npx expo prebuild                  # regenerate android/ + ios/
+npx expo run:android               # or: npx expo run:ios
+```
+
+`--no-save` overlays the local build into `node_modules`
+without rewriting `example/package.json` or its lockfile, so the committed
+dependency stays pointed at the published version.
+
+The tarball is a snapshot — there is no live reload of native or `dist/` code.
+Re-run `npm run pack` and the overlay install after each library change.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,41 @@
+# Example app end-to-end tests
+
+[Maestro](https://maestro.mobile.dev) flows that drive the example app
+against Criipto's public samples tenant (`samples.criipto.id`) to
+smoke-test the library's login path.
+
+## Prerequisites
+
+- Maestro CLI: `curl -fsSL https://get.maestro.mobile.dev | bash`
+- iOS: Xcode + an iOS Simulator.
+- Android: Android Studio + an emulator with Google Play / Chrome.
+
+Mock login can be run on a simulator, but other eID tests require the corresponding authenticator app to be installed and set up on a physical device.
+
+## Running locally
+
+The example application builds against the **published** `@criipto/verify-expo` package by default. To
+smoke-test **local, unpublished** library changes, pack the library and overlay it
+before `expo prebuild` — see [DEVELOPING.md](../DEVELOPING.md):
+
+```bash
+npm run build && npm run pack       # in the repo root
+cd example
+npm install ../criipto-verify-expo-*.tgz --no-save
+```
+
+Build and install the example app on your simulator/emulator first:
+
+```bash
+cd example
+npx expo prebuild        # one-off; generates ios/ and android/
+npx expo run:android  --variant release
+```
+
+Then invoke maestro:
+
+```bash
+maestro test e2e/maestro
+```
+
+Currently, e2e tests can only run on android, since maestro does not work well with physical iOS devices.

--- a/e2e/maestro/dk-mitid-cancel-app.yaml
+++ b/e2e/maestro/dk-mitid-cancel-app.yaml
@@ -1,0 +1,14 @@
+appId: eu.idura.expo.example
+
+
+# User cancels by rejecting from the MitID app. Currently not supported
+
+---
+- launchApp:
+    clearState: true
+- tapOn: "Login with Danish MitID"
+- tapOn: "Continue.*"
+- tapOn: "Open MitID App"
+- tapOn: "Close"
+- tapOn: "Yes"
+- assertVisible: ".*UserCancelledError.*"

--- a/e2e/maestro/dk-mitid-cancel-browser.yaml
+++ b/e2e/maestro/dk-mitid-cancel-browser.yaml
@@ -1,0 +1,12 @@
+appId: eu.idura.expo.example
+
+
+# User cancels by closing the browser
+
+---
+- launchApp:
+    clearState: true
+- tapOn: "Login with Danish MitID"
+- assertVisible: "Continue.*"
+- tapOn: "Close tab"
+- assertVisible: ".*UserCancelledError.*"

--- a/e2e/maestro/dk-mitid-cancel-ui.yaml
+++ b/e2e/maestro/dk-mitid-cancel-ui.yaml
@@ -1,0 +1,11 @@
+appId: eu.idura.expo.example
+
+
+## User cancels by clicking cancel in the MitId UI
+
+---
+- launchApp:
+    clearState: true
+- tapOn: "Login with Danish MitID"
+- tapOn: "Cancel"
+- assertVisible: ".*UserCancelledError.*"

--- a/e2e/maestro/dk-mitid-login.yaml
+++ b/e2e/maestro/dk-mitid-login.yaml
@@ -1,0 +1,25 @@
+appId: eu.idura.expo.example
+
+
+# This test assumes that:
+# * You have signed in with MitID before, and the browser remembers you username
+# * You MitID passcode is 112233
+
+---
+- launchApp:
+    clearState: true
+- tapOn: "Login with Danish MitID"
+- tapOn: "Continue.*"
+- tapOn: "Open MitID App"
+- assertVisible: "Enter PIN"
+- tapOn: "1"
+- tapOn: "1"
+- tapOn: "2"
+- tapOn: "2"
+- tapOn: "3"
+- tapOn: "3"
+- swipe:
+    start: 25%, 90%
+    end: 75%, 90%
+- assertVisible: "Logged in!"
+- assertVisible: '.*"identityscheme": "dkmitid".*'

--- a/e2e/maestro/mock-login.yaml
+++ b/e2e/maestro/mock-login.yaml
@@ -1,0 +1,8 @@
+appId: eu.idura.expo.example
+---
+- launchApp:
+    clearState: true
+- assertVisible: "Login with Mock"
+- tapOn: "Login with Mock"
+- assertVisible: "Logged in!"
+- assertVisible: '.*"identityscheme": "mock".*'

--- a/e2e/maestro/no-bankid-cancel-browser.yaml
+++ b/e2e/maestro/no-bankid-cancel-browser.yaml
@@ -1,0 +1,12 @@
+appId: eu.idura.expo.example
+
+
+# User cancels by closing the browser
+
+---
+- launchApp:
+    clearState: true
+- tapOn: "Login with Norwegian BankID"
+- assertVisible: "Confirm login"
+- tapOn: "Close tab"
+- assertVisible: ".*UserCancelledError.*"

--- a/e2e/maestro/no-bankid-cancel-ui.yaml
+++ b/e2e/maestro/no-bankid-cancel-ui.yaml
@@ -1,0 +1,13 @@
+appId: eu.idura.expo.example
+
+
+## User cancels by clicking decline in the NO BankID UI
+
+---
+- launchApp:
+    clearState: true
+- tapOn: "Login with Norwegian BankID"
+- assertVisible: "Confirm login"
+- tapOn: "Decline"
+- tapOn: "OK"
+- assertVisible: ".*UserCancelledError.*"

--- a/e2e/maestro/no-bankid-login.yaml
+++ b/e2e/maestro/no-bankid-login.yaml
@@ -1,0 +1,20 @@
+appId: eu.idura.expo.example
+
+
+# This test assumes that:
+# * You have signed in with NO BankID before, and the browser remembers you username
+# * Your device passcode is 1337
+
+---
+- launchApp:
+    clearState: true
+- tapOn: "Login with Norwegian BankID"
+- tapOn: "Confirm login"
+- tapOn: "Use PIN"
+- tapOn: "1"
+- tapOn: "3"
+- tapOn: "3"
+- tapOn: "7"
+- tapOn: "Next"
+- assertVisible: "Logged in!"
+- assertVisible: '.*"identityscheme": "nobankid.*'

--- a/e2e/maestro/no-vipps-cancel-app.yaml
+++ b/e2e/maestro/no-vipps-cancel-app.yaml
@@ -1,0 +1,25 @@
+appId: eu.idura.expo.example
+
+
+# User cancels by rejecting the login request in the Vipps app
+
+---
+- launchApp:
+    clearState: true
+- tapOn: "Login with Vipps MobilePay"
+- tapOn: "Open Vipps"
+# If Vipps is locked, unlock with PIN 1236 (skip the fingerprint prompt).
+- runFlow:
+    when:
+      visible: "Enter your code"
+    commands:
+      - tapOn: "Enter your code"
+      - tapOn: "1"
+      - tapOn: "2"
+      - tapOn: "3"
+      - tapOn: "6"
+- assertVisible: "Do you want to log in to Criipto?"
+- tapOn: "Cancel"
+- assertVisible: "Are you sure you want to cancel log in?"
+- tapOn: "Yes"
+- assertVisible: ".*UserCancelledError.*"

--- a/e2e/maestro/no-vipps-cancel-browser.yaml
+++ b/e2e/maestro/no-vipps-cancel-browser.yaml
@@ -1,0 +1,12 @@
+appId: eu.idura.expo.example
+
+
+# User cancels by closing the browser
+
+---
+- launchApp:
+    clearState: true
+- tapOn: "Login with Vipps MobilePay"
+- assertVisible: "Open Vipps"
+- tapOn: "Close tab"
+- assertVisible: ".*UserCancelledError.*"

--- a/e2e/maestro/no-vipps-cancel-ui.yaml
+++ b/e2e/maestro/no-vipps-cancel-ui.yaml
@@ -1,0 +1,12 @@
+appId: eu.idura.expo.example
+
+
+## User cancels by clicking cancel on the Criipto Vipps page
+
+---
+- launchApp:
+    clearState: true
+- tapOn: "Login with Vipps MobilePay"
+- assertVisible: "Open Vipps"
+- tapOn: "Cancel and go back to Criipto"
+- assertVisible: ".*UserCancelledError.*"

--- a/e2e/maestro/no-vipps-login.yaml
+++ b/e2e/maestro/no-vipps-login.yaml
@@ -1,0 +1,39 @@
+appId: eu.idura.expo.example
+
+
+# This test assumes:
+# * The Vipps MobilePay app is installed and signed in as a test user.
+# * That user's Vipps PIN is 1236.
+#
+# Two steps are state-dependent and therefore conditional:
+# * The PIN unlock only appears when Vipps has locked itself (session timeout).
+#   When it does, Vipps shows the system biometric prompt; we fall back to the
+#   PIN pad via "Enter your code". Maestro can't satisfy the fingerprint sensor.
+# * The browser consent page is shown only the first time; Vipps remembers the
+#   consent for a year, so on later runs the flow returns straight to the app.
+
+---
+- launchApp:
+    clearState: true
+- tapOn: "Login with Vipps MobilePay"
+- tapOn: "Open Vipps"
+# If Vipps is locked, unlock with PIN 1236 (skip the fingerprint prompt).
+- runFlow:
+    when:
+      visible: "Enter your code"
+    commands:
+      - tapOn: "Enter your code"
+      - tapOn: "1"
+      - tapOn: "2"
+      - tapOn: "3"
+      - tapOn: "6"
+- assertVisible: "Do you want to log in to Criipto?"
+- tapOn: "Continue"
+# First-time data-sharing consent in the browser (remembered for a year).
+- runFlow:
+    when:
+      visible: "Continue as.*"
+    commands:
+      - tapOn: "Continue as.*"
+- assertVisible: "Logged in!"
+- assertVisible: '.*"identityscheme": "novipps.*'

--- a/e2e/maestro/se-bankid-cancel-app.yaml
+++ b/e2e/maestro/se-bankid-cancel-app.yaml
@@ -1,0 +1,8 @@
+appId: eu.idura.expo.example
+---
+- launchApp:
+    clearState: true
+- tapOn: "Login with Swedish BankID"
+- tapOn: "Open"
+- tapOn: "Navigate up"
+- assertVisible: ".*UserCancelledError.*"

--- a/e2e/maestro/se-bankid-cancel-browser.yaml
+++ b/e2e/maestro/se-bankid-cancel-browser.yaml
@@ -1,0 +1,12 @@
+appId: eu.idura.expo.example
+
+
+# User cancels by closing the browser
+
+---
+- launchApp:
+    clearState: true
+- tapOn: "Login with Swedish BankID"
+- assertVisible: 'Open page in "BankID"'
+- tapOn: "Close tab"
+- assertVisible: ".*UserCancelledError.*"

--- a/example/App.js
+++ b/example/App.js
@@ -48,6 +48,10 @@ function LoginButton() {
         onPress={() => handlePress("urn:grn:authn:no:bankid:substantial")}
         title="Login with Norwegian BankID"
       />
+      <Button
+        onPress={() => handlePress("urn:grn:authn:no:vipps")}
+        title="Login with Vipps MobilePay"
+      />
       <Button onPress={() => handlePress("urn:grn:authn:mock")} title="Login with Mock" />
 
       {error ? <Text>An error occurred: {error.toString()}</Text> : null}

--- a/example/App.js
+++ b/example/App.js
@@ -56,7 +56,12 @@ function LoginButton() {
 
       {error ? <Text>An error occurred: {error.toString()}</Text> : null}
 
-      {claims ? <Text>{JSON.stringify(claims, null, 2)}</Text> : null}
+      {claims ? (
+        <>
+          <Text>Logged in!</Text>
+          <Text>{JSON.stringify(claims, null, 2)}</Text>
+        </>
+      ) : null}
     </>
   );
 }

--- a/example/app.json
+++ b/example/app.json
@@ -14,14 +14,15 @@
     "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "eu.idura.example"
+      "bundleIdentifier": "eu.idura.expo.example",
+      "appleTeamId": "P56KU6NT8A"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "package": "eu.idura.example"
+      "package": "eu.idura.expo.example"
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -16,13 +16,12 @@
         "react-native": "0.81.5"
       },
       "devDependencies": {
-        "@babel/core": "^7.20.0",
-        "expo-dev-client": "~6.0.20"
+        "@babel/core": "^7.20.0"
       }
     },
     "..": {
       "name": "@criipto/verify-expo",
-      "version": "3.0.4",
+      "version": "4.0.0-1",
       "license": "MIT",
       "dependencies": {
         "expo-modules-core": "^3.0.28",
@@ -3943,61 +3942,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo-dev-client": {
-      "version": "6.0.20",
-      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-6.0.20.tgz",
-      "integrity": "sha512-5XjoVlj1OxakNxy55j/AUaGPrDOlQlB6XdHLLWAw61w5ffSpUDHDnuZzKzs9xY1eIaogOqTOQaAzZ2ddBkdXLA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expo-dev-launcher": "6.0.20",
-        "expo-dev-menu": "7.0.18",
-        "expo-dev-menu-interface": "2.0.0",
-        "expo-manifests": "~1.0.10",
-        "expo-updates-interface": "~2.0.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-dev-launcher": {
-      "version": "6.0.20",
-      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-6.0.20.tgz",
-      "integrity": "sha512-a04zHEeT9sB0L5EB38fz7sNnUKJ2Ar1pXpcyl60Ki8bXPNCs9rjY7NuYrDkP/irM8+1DklMBqHpyHiLyJ/R+EA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.11.0",
-        "expo-dev-menu": "7.0.18",
-        "expo-manifests": "~1.0.10"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-dev-menu": {
-      "version": "7.0.18",
-      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-7.0.18.tgz",
-      "integrity": "sha512-4kTdlHrnZCAWCT6tZRQHSSjZ7vECFisL4T+nsG/GJDo/jcHNaOVGV5qPV9wzlTxyMk3YOPggRw4+g7Ownrg5eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expo-dev-menu-interface": "2.0.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-dev-menu-interface": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-2.0.0.tgz",
-      "integrity": "sha512-BvAMPt6x+vyXpThsyjjOYyjwfjREV4OOpQkZ0tNl+nGpsPfcY9mc6DRACoWnH9KpLzyIt3BOgh3cuy/h/OxQjw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
     "node_modules/expo-file-system": {
       "version": "19.0.21",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.21.tgz",
@@ -4022,13 +3966,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo-json-utils": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.15.0.tgz",
-      "integrity": "sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/expo-keep-awake": {
       "version": "15.0.8",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-15.0.8.tgz",
@@ -4037,20 +3974,6 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
-      }
-    },
-    "node_modules/expo-manifests": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-1.0.10.tgz",
-      "integrity": "sha512-oxDUnURPcL4ZsOBY6X1DGWGuoZgVAFzp6PISWV7lPP2J0r8u1/ucuChBgpK7u1eLGFp6sDIPwXyEUCkI386XSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config": "~12.0.11",
-        "expo-json-utils": "~0.15.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -4102,16 +4025,6 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/expo-updates-interface": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-2.0.0.tgz",
-      "integrity": "sha512-pTzAIufEZdVPKql6iMi5ylVSPqV1qbEopz9G6TSECQmnNde2nwq42PxdFBaUEd8IZJ/fdJLQnOT3m6+XJ5s7jg==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*"
       }
     },
     "node_modules/exponential-backoff": {

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example",
       "version": "2.0.0",
       "dependencies": {
-        "@criipto/verify-expo": "..",
+        "@criipto/verify-expo": "^4.0.0-2",
         "expo": "~54.0.33",
         "expo-build-properties": "~1.0.10",
         "expo-status-bar": "~3.0.9",
@@ -17,31 +17,6 @@
       },
       "devDependencies": {
         "@babel/core": "^7.20.0"
-      }
-    },
-    "..": {
-      "name": "@criipto/verify-expo",
-      "version": "4.0.0-1",
-      "license": "MIT",
-      "dependencies": {
-        "expo-modules-core": "^3.0.28",
-        "jwt-decode": "^3.1.2"
-      },
-      "devDependencies": {
-        "@types/react": "^19.1.9",
-        "@types/react-native": "^0.72.2",
-        "husky": "^9.1.7",
-        "lint-staged": "^16.2.7",
-        "prettier": "^3.7.4",
-        "publint": "^0.3.20",
-        "react-native": "^0.79.6",
-        "tsdown": "^0.22.0",
-        "typescript": "^5.1.6"
-      },
-      "peerDependencies": {
-        "expo": ">=54",
-        "react": ">=19",
-        "react-native": ">=0.81"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -1521,8 +1496,19 @@
       }
     },
     "node_modules/@criipto/verify-expo": {
-      "resolved": "..",
-      "link": true
+      "version": "4.0.0-2",
+      "resolved": "https://registry.npmjs.org/@criipto/verify-expo/-/verify-expo-4.0.0-2.tgz",
+      "integrity": "sha512-7LFDD8L0rv9/KvYhl3Ys0Fx7qNYIaShMv1Qv4yIG2c8rr9nmxuplvLhGPVKSMAVVoU/vpeVou8063JS0mjr9Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwt-decode": "^3.1.2"
+      },
+      "peerDependencies": {
+        "expo": ">=54",
+        "expo-modules-core": ">=3",
+        "react": ">=19",
+        "react-native": ">=0.81"
+      }
     },
     "node_modules/@expo/cli": {
       "version": "54.0.23",
@@ -4800,6 +4786,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==",
+      "license": "MIT"
     },
     "node_modules/kleur": {
       "version": "3.0.3",

--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@criipto/verify-expo": "..",
+    "@criipto/verify-expo": "^4.0.0-2",
     "expo": "~54.0.33",
     "expo-build-properties": "~1.0.10",
     "expo-status-bar": "~3.0.9",

--- a/example/package.json
+++ b/example/package.json
@@ -17,8 +17,7 @@
     "react-native": "0.81.5"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0",
-    "expo-dev-client": "~6.0.20"
+    "@babel/core": "^7.20.0"
   },
   "overrides": {
     "@criipto/verify-expo": {


### PR DESCRIPTION
## Summary

Sets up e2e testing with maestro. Maestro was chosen over Detox et. al., because the login flow crosses process boundaries (ASWebAuthenticationSession on iOS, Chrome Custom Tab on Android) which Detox cannot drive, whereas Maestro operates at the OS-level UI.

Most tests were written by hand, but on the Vipps tests I let claude take the wheel 🕺 🤖. It was pretty slow going, but it was able to add the button to the example app, and iteratively run the flow to completion.

FrejaID is not tested, since it disables screenshots and accessibility services, so there is no way to see what's on the screen :(.

SE BankID detects when you automate taps on the in-app keypad, and fails the flow, so login is not tested here. I'm hoping I can find another automation approach that we can use in the android SDK, but its not tested here.

A follow-up PR will wire this flow into CI


🤖 Generated with [Claude Code](https://claude.com/claude-code)