### PR TITLE
Pass --tag to npm publish so prerelease releases succeed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,4 +19,4 @@ jobs:
         run: npm install -g npm@11.5.1
       - run: npm ci
       - run: npm run check
-      - run: npm publish --provenance
+      - run: npm publish --provenance --tag ${{ github.event.release.prerelease && 'beta' || 'latest' }}


### PR DESCRIPTION
## Summary
- npm publish refuses to publish a prerelease version (e.g. `4.0.0-0`) without an explicit `--tag`, which broke the Publish workflow on the latest GitHub release.
- Derives the dist-tag from `github.event.release.prerelease`: prereleases publish under `beta`, stable releases keep `latest`.

## Test plan
- [ ] Re-run / re-trigger the failed prerelease publish and confirm `4.0.0-0` lands on the `beta` dist-tag (and `latest` still points at `3.0.4`).
- [ ] On the next stable (non-prerelease) GitHub release, confirm publish goes to `latest` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)