### PR TITLE
Build and smoke-test the example app in CI with EAS Workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,24 @@
+name: e2e
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # Forked PRs cannot read the EXPO_TOKEN secret, so only run for same-repo events.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+      - run: npm install --global eas-cli
+      - name: Run the EAS e2e workflow
+        run: eas workflow:run .eas/workflows/e2e.yml --wait --non-interactive
+        working-directory: example
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -60,3 +60,12 @@ dependency stays pointed at the published version.
 
 The tarball is a snapshot — there is no live reload of native or `dist/` code.
 Re-run `npm run pack` and the overlay install after each library change.
+
+### On EAS Build
+
+EAS workers reinstall `example/` dependencies from the lockfile, which points at
+the published package — a locally overlaid tarball does not survive the upload.
+The `eas-build-post-install` hook in `example/package.json` therefore repeats
+the overlay on the worker: it packs the library at the repo root and installs
+the tarball into the example, so EAS builds (and the
+[e2e workflow](e2e/README.md)) test the checked-out library code.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -38,4 +38,26 @@ Then invoke maestro:
 maestro test e2e/maestro
 ```
 
-Currently, e2e tests can only run on android, since maestro does not work well with physical iOS devices.
+Currently, local e2e tests can only run on android, since maestro does not work well with physical iOS devices.
+
+## Running on CI (EAS Workflows)
+
+The [`e2e` workflow](../example/.eas/workflows/e2e.yml) builds the example app
+on [EAS Build](https://docs.expo.dev/build/introduction/) (iOS simulator build
+and Android APK) and runs `mock-login.yaml` on EAS-managed simulators/emulators
+via the [`maestro` job](https://docs.expo.dev/eas/workflows/examples/e2e-tests/).
+Only the mock flow runs on CI — the other flows need eID authenticator apps on
+physical devices.
+
+The build uses the `e2e-test` profile in [`eas.json`](../example/eas.json), and
+an `eas-build-post-install` hook overlays the locally packed library before
+prebuild (the same tarball overlay described in
+[DEVELOPING.md](../DEVELOPING.md)), so CI tests the checked-out library code,
+not the published package.
+
+Trigger manually with:
+
+```bash
+cd example
+eas workflow:run .eas/workflows/e2e.yml
+```

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -55,6 +55,13 @@ prebuild (the same tarball overlay described in
 [DEVELOPING.md](../DEVELOPING.md)), so CI tests the checked-out library code,
 not the published package.
 
+The [GitHub Actions `e2e` workflow](../.github/workflows/e2e.yml) starts the
+EAS workflow on pull requests and pushes to master with `eas workflow:run`
+(uploading the local checkout) and gates on its result. The repo is
+deliberately **not** linked to the Expo GitHub app; authentication uses the
+`EXPO_TOKEN` repository secret. Forked PRs cannot read the secret, so the job
+only runs for same-repo events.
+
 Trigger manually with:
 
 ```bash

--- a/e2e/maestro/mock-login.yaml
+++ b/e2e/maestro/mock-login.yaml
@@ -4,5 +4,18 @@ appId: eu.idura.expo.example
     clearState: true
 - assertVisible: "Login with Mock"
 - tapOn: "Login with Mock"
-- assertVisible: "Logged in!"
+# If iOS shows the "... Wants to Use criipto.id to Sign In" consent alert
+# before opening the browser session, pass it; with ephemeral sessions no
+# alert appears and this is skipped.
+- runFlow:
+    when:
+      platform: iOS
+      visible: "Continue"
+    commands:
+      - tapOn: "Continue"
+# The browser round-trip can outlast the default assertion wait on cold CI
+# simulators.
+- extendedWaitUntil:
+    visible: "Logged in!"
+    timeout: 60000
 - assertVisible: '.*"identityscheme": "mock".*'

--- a/example/.eas/workflows/e2e.yml
+++ b/example/.eas/workflows/e2e.yml
@@ -1,0 +1,37 @@
+# Maestro smoke tests for the example app, on EAS-managed simulators/emulators.
+# The example builds against the PR's library code: an eas-build-post-install
+# hook in package.json packs the repo-root library and overlays it before
+# prebuild (see DEVELOPING.md).
+#
+# No `on:` triggers — the repo is intentionally not linked to the Expo GitHub
+# app. GitHub Actions starts this workflow with `eas workflow:run` (see
+# .github/workflows/e2e.yml), which uploads the local checkout.
+name: e2e
+
+jobs:
+  build_ios:
+    name: Build iOS simulator app
+    type: build
+    params:
+      platform: ios
+      profile: e2e-test
+  build_android:
+    name: Build Android apk
+    type: build
+    params:
+      platform: android
+      profile: e2e-test
+  test_ios:
+    name: Maestro (iOS)
+    needs: [build_ios]
+    type: maestro
+    params:
+      build_id: ${{ needs.build_ios.outputs.build_id }}
+      flow_path: ["../e2e/maestro/mock-login.yaml"]
+  test_android:
+    name: Maestro (Android)
+    needs: [build_android]
+    type: maestro
+    params:
+      build_id: ${{ needs.build_android.outputs.build_id }}
+      flow_path: ["../e2e/maestro/mock-login.yaml"]

--- a/example/app.json
+++ b/example/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
     "name": "Criipto Verify Expo Example",
-    "slug": "example",
+    "slug": "criipto-verify-expo",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -48,6 +48,12 @@
           "clientID": "urn:criipto:samples:criipto-verify-expo"
         }
       ]
-    ]
+    ],
+    "extra": {
+      "eas": {
+        "projectId": "03dd1359-60f3-4d88-8473-e1c031e22707"
+      }
+    },
+    "owner": "janiduras-organization"
   }
 }

--- a/example/eas.json
+++ b/example/eas.json
@@ -1,0 +1,18 @@
+{
+  "cli": {
+    "version": ">= 20.0.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "e2e-test": {
+      "node": "24.13.1",
+      "ios": {
+        "simulator": true
+      },
+      "android": {
+        "buildType": "apk",
+        "withoutCredentials": true
+      }
+    }
+  }
+}

--- a/example/package.json
+++ b/example/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "eas-build-post-install": "cd .. && npm ci --ignore-scripts && npm run pack && cd example && npm install ../criipto-verify-expo-*.tgz --no-save"
   },
   "dependencies": {
     "@criipto/verify-expo": "^4.0.0-2",


### PR DESCRIPTION
## Summary
In https://github.com/criipto/criipto-verify-expo/pull/27, I added a CI step that builds the example app, and runs the maestro mock test, in github actions. However, that is both slow and brittle! Especially on iOS, which is both slow to build (9 minutes to build app for simulator), and has to retry the test several times, because app link entitlements are slow to resolve.

Expo already offers a hosted build service, which also allows us to run the maestro tests. So let's use that instead!


## Testing

- The `e2e` check on this PR is green through the real trigger chain (GitHub Actions → `eas workflow:run` → builds → Maestro), twice.
- **Failure injection** — verified CI tests the PR's code, not the published package:
  - #37 sabotaged the JS layer (mangled acr value): builds ✅, Maestro ❌ on **both** platforms — the PR's JS is what gets bundled.
  - #38 sabotaged the iOS Swift module (corrupted return token): Maestro ❌ on iOS, ✅ on Android — the PR's native code is what gets compiled, and failures localize to the affected platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
