### PR TITLE
test: e2e must fail on sabotaged JS (DO NOT MERGE)

### DIFF
--- a/src/CriiptoVerifyExpoModule.ts
+++ b/src/CriiptoVerifyExpoModule.ts
@@ -40,7 +40,12 @@ export interface LoginResult {
  */
 export async function login(params: LoginParams): Promise<LoginResult> {
   const module = requireNativeModule("CriiptoVerifyExpo");
-  const result: NativeLoginResult = await module.login(params);
+  // DO NOT MERGE: deliberately mangle the acr value so the e2e mock login
+  // fails — verifies CI tests the checked-out JS, not the published package.
+  const result: NativeLoginResult = await module.login({
+    ...params,
+    acrValues: `${params.acrValues}:sabotaged`,
+  });
   switch (result.kind) {
     case "Success":
       return {


### PR DESCRIPTION
**Throwaway verification PR — DO NOT MERGE.**

Deliberately mangles the acr value in the library's JS layer. If CI tests the checked-out library (tarball overlay), the `e2e` check must **fail on both platforms** (mock login errors out). If it stays green, CI is testing the published npm package instead of the PR.

Expected: ❌ Maestro (iOS), ❌ Maestro (Android).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
