### PR TITLE
test: e2e must fail on sabotaged iOS native code (DO NOT MERGE)

### DIFF
--- a/ios/CriiptoVerifyExpoModule.swift
+++ b/ios/CriiptoVerifyExpoModule.swift
@@ -65,8 +65,11 @@ public class CriiptoVerifyExpoModule: Module {
         prompt: prompt,
         useEphemeralBrowserSession: params.preferEphemeralSession
       )
+      // DO NOT MERGE: deliberately corrupt the returned token so the e2e mock
+      // login fails on iOS only — verifies CI compiles the checked-out native
+      // code, not the published package. Android must stay green.
       return NativeLoginResult.Success(
-        idToken: result.jwt.idToken,
+        idToken: String(result.jwt.idToken.reversed()),
         traceId: result.traceId
       ).toDictionary()
     } catch let iduraError as IduraVerifyError {


### PR DESCRIPTION
**Throwaway verification PR — DO NOT MERGE.**

Deliberately corrupts the token returned by the iOS Swift module. If CI compiles the checked-out native code (tarball overlay), the `e2e` check must **fail on iOS while Android stays green** — the green Android leg is the control.

Expected: ❌ Maestro (iOS), ✅ Maestro (Android).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
