### PR TITLE
ci: run the check workflow on pull requests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,5 +1,8 @@
 name: check
-on: push
+on:
+  push:
+    branches: ["master"]
+  pull_request:
 permissions:
   contents: read
   id-token: write


### PR DESCRIPTION
The `check` workflow only triggered on `push`. A pull request from a fork therefore produced no lint or type-check signal, because the push event fires in the contributor's fork rather than here — as seen on #41.

Adding `pull_request` closes that gap. `push` narrows to `master` so same-repo branches do not run the job twice, and the post-merge signal stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)