### PR TITLE
ci: pin the Maestro Android emulator to an API 36 image

### DIFF
--- a/examples/expo54/.eas/workflows/e2e.yml
+++ b/examples/expo54/.eas/workflows/e2e.yml
@@ -35,3 +35,12 @@ jobs:
     params:
       build_id: ${{ needs.build_android.outputs.build_id }}
       flow_path: ["../../e2e/maestro/mock-login.yaml"]
+      device_identifier: pixel_9
+      android_system_image_package: "system-images;android-36;google_apis_playstore;x86_64"
+    hooks:
+      before_maestro_tests:
+        - name: Skip Chrome's first-run experience
+          run: |
+            adb shell 'echo "_ --disable-fre --no-first-run --no-default-browser-check" > /data/local/tmp/chrome-command-line'
+            adb shell chmod 0644 /data/local/tmp/chrome-command-line
+            adb shell am set-debug-app --persistent com.android.chrome

--- a/examples/expo55/.eas/workflows/e2e.yml
+++ b/examples/expo55/.eas/workflows/e2e.yml
@@ -35,3 +35,12 @@ jobs:
     params:
       build_id: ${{ needs.build_android.outputs.build_id }}
       flow_path: ["../../e2e/maestro/mock-login.yaml"]
+      device_identifier: pixel_9
+      android_system_image_package: "system-images;android-36;google_apis_playstore;x86_64"
+    hooks:
+      before_maestro_tests:
+        - name: Skip Chrome's first-run experience
+          run: |
+            adb shell 'echo "_ --disable-fre --no-first-run --no-default-browser-check" > /data/local/tmp/chrome-command-line'
+            adb shell chmod 0644 /data/local/tmp/chrome-command-line
+            adb shell am set-debug-app --persistent com.android.chrome

--- a/examples/expo56/.eas/workflows/e2e.yml
+++ b/examples/expo56/.eas/workflows/e2e.yml
@@ -35,3 +35,12 @@ jobs:
     params:
       build_id: ${{ needs.build_android.outputs.build_id }}
       flow_path: ["../../e2e/maestro/mock-login.yaml"]
+      device_identifier: pixel_9
+      android_system_image_package: "system-images;android-36;google_apis_playstore;x86_64"
+    hooks:
+      before_maestro_tests:
+        - name: Skip Chrome's first-run experience
+          run: |
+            adb shell 'echo "_ --disable-fre --no-first-run --no-default-browser-check" > /data/local/tmp/chrome-command-line'
+            adb shell chmod 0644 /data/local/tmp/chrome-command-line
+            adb shell am set-debug-app --persistent com.android.chrome


### PR DESCRIPTION
The e2e Android flows have failed on every run since `*.criipto.id` rotated to a certificate chaining to *Sectigo Public Server Authentication Root E46*. EAS defaults to an Android 11 / API 30 emulator whose CA store predates that root, so OIDC discovery fails the TLS handshake (`Trust anchor for certification path not found`) and the app shows `IduraVerifyInternalError: Network error`.

Confirmed by installing one APK built from master on two local AVDs: API 30 fails identically, API 36 passes. The pinned image and device mirror that passing AVD (`pixel_9` is Play Store compatible, and the Play Store tag guarantees Chrome for the Custom Tabs leg).


🤖 Generated with [Claude Code](https://claude.com/claude-code)